### PR TITLE
refactor: task_option()

### DIFF
--- a/plugin/asynctasks.vim
+++ b/plugin/asynctasks.vim
@@ -876,7 +876,7 @@ function! s:task_option(task)
 		elseif output =~ '^term'
 			let opts.mode = 'term'
 			let opts.output = 'term'
-			let opts.pos = match(output, ':') > 0 ? split(output, ':')[1] : 'bottom'
+			let opts.pos = match(output, ':') > 0 ? split(output, ':')[1] : get(task, 'pos', 'bottom')
 			let opts.cols = g:asynctasks_term_cols
 			let opts.rows = g:asynctasks_term_rows
 			let opts.focus = g:asynctasks_term_focus

--- a/plugin/asynctasks.vim
+++ b/plugin/asynctasks.vim
@@ -846,12 +846,12 @@ function! s:task_option(task)
 	let opts = {
 				\ 'mode':        get(task, 'mode', 'async'),
 				\ 'cwd':         get(task, 'cwd', ''),
-				\ 'raw':         get(task, 'raw', 1),
+				\ 'raw':         get(task, 'raw', 0),
 				\ 'save':        get(task, 'save', 1),
 				\ 'silent':      get(task, 'silent', 0),
 				\ 'program':     get(task, 'program', ''),
 				\ 'auto':        get(task, 'auto', 0),
-				\ 'errorformat': get(task, 'errorformat', ''),
+				\ 'errorformat': get(task, 'errorformat', &errorformat),
 				\ 'strip':       get(task, 'strip', 0),
 				\ 'output':      get(task, 'output', 'quickfix'),
 				\ 'listed':      get(task, 'listed', g:asynctasks_term_listed),
@@ -871,6 +871,8 @@ function! s:task_option(task)
 			let opts.mode = 'bang'
 		elseif output == 'hide'
 			let opts.mode = 'hide'
+		elseif output == 'raw'
+			let opts.raw = 1
 		elseif s:windows && get(g:, 'asyncrun_gui', 0) != 0
 			let opts.mode = 'system'
 		elseif output =~ '^term'


### PR DESCRIPTION
(this PR is mostly for discussion, not for merging)

This part is a bit messed up. I set `output` as `terminal` and it still opened the quickfix. I set `output` to `external` and it still *opens* the quickfix. Yes I read about creating a runner, but these things should work without needing customization. Setting `external` does nothing at all at this point. Also I don't understand why `external` or a runner would go in `pos`. For me it should be:

`mode`:
- `quickfix` (default)
- `cmdline` (currently named `vim`)
- `terminal`: in vim/nvim internal terminal
- `external`: in a default external terminal (no custom runner needed)
- `...`: a custom runner

`pos`: it would only make sense with the terminal option.

In this PR I made possible to set the position like:

    output=terminal:top

But `external` should work with some default command. For example in Linux `x-terminal-emulator` can be used to open default terminal (in Windows you will know better).
